### PR TITLE
Support commented-out image entries in kustomization files

### DIFF
--- a/.github/workflows/update_kubernetes_deployment.yml
+++ b/.github/workflows/update_kubernetes_deployment.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           KUSTOMIZATION_FILE="k8s_kustomize/overlays/${{ inputs.environment }}/kustomization.yaml"
 
-          GREP_RESULT=$(grep -n -x "  newName: ${{ inputs.registry }}/${{ inputs.image_name }}" "$KUSTOMIZATION_FILE" | cut -d ':' -f 1)
+          GREP_RESULT=$(grep -n "newName: ${{ inputs.registry }}/${{ inputs.image_name }}$" "$KUSTOMIZATION_FILE" | cut -d ':' -f 1)
           if [ -z "$GREP_RESULT" ]; then
             echo "Error: Image ${{ inputs.registry }}/${{ inputs.image_name }} not found in $KUSTOMIZATION_FILE"
             exit 1


### PR DESCRIPTION
## Summary

Fixes the `update_kubernetes_deployment.yml` reusable workflow to also update image tags on commented-out kustomization entries, which are used as templates for the promote-to-production pipeline.

## Problem

The `grep -n -x` (exact full-line match) only matched active (uncommented) `newName` lines like:

```yaml
    newName: auroradevacr.azurecr.io/robotics/isar-anymal
```

But several overlays in `robotics-infrastructure` have commented-out template entries that also need their tags updated:

```yaml
#   newName: auroradevacr.azurecr.io/robotics/isar-anymal
```

The `-x` flag requires the entire line to match, so lines prefixed with `#` and varying whitespace were never found, causing the workflow to fail with "Image not found".

## Fix

Replace `grep -n -x "  newName: ..."` with `grep -n "newName: ...$"`:

- **Drop `-x`**: no longer requires full-line exact match, so `#`-prefixed lines are found
- **Add `$` anchor**: prevents partial image name matches (e.g. `robotics/sara` won't match `robotics/sara-anonymizer`)

The `sed` replacement on the next line already works correctly for both commented and uncommented `newTag:` lines, so no other changes are needed.