### PR TITLE
Add centralized reusable workflow for .NET lint and test

### DIFF
--- a/.github/workflows/test_and_lint_dotnet_package.yml
+++ b/.github/workflows/test_and_lint_dotnet_package.yml
@@ -1,0 +1,92 @@
+name: Test and lint dotnet package
+
+on:
+  workflow_call:
+    inputs:
+      dotnet_version:
+        description: ".NET SDK version to use"
+        required: false
+        type: string
+        default: "10.0.x"
+
+      build_directory:
+        description: "Directory for dotnet build"
+        required: true
+        type: string
+
+      test_directory:
+        description: "Directory for dotnet build -warnaserror and dotnet test. Defaults to build_directory."
+        required: false
+        type: string
+        default: ""
+
+      format_directory:
+        description: "Directory for CSharpier format check. Defaults to build_directory."
+        required: false
+        type: string
+        default: ""
+
+# Permissions must be provided from calling workflow
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5
+        with:
+          dotnet-version: ${{ inputs.dotnet_version }}
+
+      - name: Build project and dependencies
+        working-directory: ${{ inputs.build_directory }}
+        run: dotnet build
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5
+        with:
+          dotnet-version: ${{ inputs.dotnet_version }}
+
+      - name: Build project and dependencies
+        working-directory: ${{ inputs.test_directory || inputs.build_directory }}
+        run: dotnet build -warnaserror
+
+      - name: Run tests
+        working-directory: ${{ inputs.test_directory || inputs.build_directory }}
+        run: dotnet test
+
+  check_formatting:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5
+        with:
+          dotnet-version: ${{ inputs.dotnet_version }}
+
+      - name: Run csharpier format check
+        working-directory: ${{ inputs.format_directory || inputs.build_directory }}
+        run: |
+          dotnet tool restore
+          dotnet csharpier check .


### PR DESCRIPTION
## Summary

Adds a new centralized reusable workflow `test_and_lint_dotnet_package.yml` for .NET projects, replacing the duplicated `backend_lint_and_test.yml` workflows in flotilla and sara.

Mirrors the existing `test_and_lint_python_package.yml` pattern for the C# / .NET side of the platform.

## Changes

- New workflow `.github/workflows/test_and_lint_dotnet_package.yml` with three parallel jobs:
  - **Build**: `dotnet build`
  - **Test**: `dotnet build -warnaserror` + `dotnet test`
  - **Check formatting**: `dotnet tool restore` + `dotnet csharpier check .`

## Inputs

| Input | Required | Default | Description |
|---|---|---|---|
| `dotnet_version` | No | `"10.0.x"` | .NET SDK version |
| `build_directory` | Yes | — | Directory for `dotnet build` |
| `test_directory` | No | Falls back to `build_directory` | Directory for `dotnet build -warnaserror` and `dotnet test` |
| `format_directory` | No | Falls back to `build_directory` | Directory for CSharpier format check |

The `test_directory` and `format_directory` inputs allow repos where the test project lives in a separate directory (e.g. sara uses `api/` for build/format but `api.Tests/` for tests).

Actions are pinned by full commit SHA, consistent with existing armada workflows.