### PR TITLE
Add reusable Trivy config scan workflow

### DIFF
--- a/.github/workflows/trivy_config_scan.yml
+++ b/.github/workflows/trivy_config_scan.yml
@@ -1,0 +1,48 @@
+name: Trivy IaC and Dockerfile scanning
+
+on:
+  workflow_call:
+    inputs:
+      skip_dirs:
+        description: "Comma-separated list of directories to skip (passed to trivy --skip-dirs)"
+        required: false
+        type: string
+        default: ""
+
+# Permissions must be provided from calling workflow
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+
+jobs:
+  trivy-scan:
+    name: Scan with Trivy
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        with:
+          persist-credentials: false
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+        with:
+          scan-type: 'config'
+          severity: 'CRITICAL,HIGH'
+          limit-severities-for-sarif: true
+          format: 'sarif'
+          output: 'trivy-results-iac.sarif'
+          exit-code: '0'
+          skip-dirs: ${{ inputs.skip_dirs }}
+
+      - name: Upload scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 #v4
+        with:
+          sarif_file: 'trivy-results-iac.sarif'


### PR DESCRIPTION
## Summary
- Add centralized reusable workflow for Trivy IaC & Dockerfile scanning
- Supports optional `skip_dirs` input for infrastructure repos that need to exclude directories (e.g. Kustomize patches)
- All actions pinned by full commit SHA
- To be consumed by all repositories that currently have a standalone `trivy-config.yml`, plus 5 repos that don't yet have Trivy scanning