### PR TITLE
Add Trivy config scan workflow

### DIFF
--- a/.github/workflows/trivy_config_scan_caller.yml
+++ b/.github/workflows/trivy_config_scan_caller.yml
@@ -1,0 +1,22 @@
+name: Trivy IaC & Dockerfile Scanning
+
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "36 0 * * 3"
+
+jobs:
+  trivy-scan:
+    uses: equinor/armada/.github/workflows/trivy_config_scan.yml@main
+    permissions:
+      security-events: write
+      contents: read
+      actions: read


### PR DESCRIPTION
## Summary
- Add Trivy IaC & Dockerfile scanning by calling the centralized reusable workflow in armada
- Scans on push/PR to main and weekly on schedule
- Results uploaded to the GitHub Security tab