### PR TITLE
Update trivy-action to v0.35.0

### DIFF
--- a/.github/workflows/trivy_config_scan.yml
+++ b/.github/workflows/trivy_config_scan.yml
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 #v0.35.0
         with:
           scan-type: 'config'
           severity: 'CRITICAL,HIGH'


### PR DESCRIPTION
## Summary
- Update `aquasecurity/trivy-action` from v0.33.1 to v0.35.0 (SHA-pinned)
- Fixes binary download failure for repos without a cached Trivy binary — `get.trivy.dev` returns 404 for v0.65.0 (the version bundled with v0.33.1), causing all 5 newly added Trivy workflows to fail
- The 11 repos that already had Trivy running were unaffected because they had the binary cached from previous runs