### PR TITLE
Fix sara health check request path

### DIFF
--- a/robotics_integration_tests/utilities/sara_backend_api.py
+++ b/robotics_integration_tests/utilities/sara_backend_api.py
@@ -42,7 +42,7 @@ def wait_for_sara_to_be_responsive(sara_url: str, timeout: int = 60) -> None:
 
         try:
             analysis_mapping: List[Dict] = _list_database_entries(
-                backend_url=sara_url, request_path="AnalysisMapping"
+                backend_url=sara_url, request_path="api/AnalysisMapping"
             )
         except Exception as e:
             logger.warning(


### PR DESCRIPTION
## Summary
- Add missing `api/` prefix to the Sara health check path in `wait_for_sara_to_be_responsive`, fixing integration test failures