### PR TITLE
Add project-path input to test workflow

### DIFF
--- a/.github/workflows/test_and_lint_python_package.yml
+++ b/.github/workflows/test_and_lint_python_package.yml
@@ -45,6 +45,12 @@ on:
         type: string
         default: ''
 
+      project-path:
+        description: "Path to the project directory containing pyproject.toml"
+        required: false
+        type: string
+        default: '.'
+
 # Permissions must be provided from calling workflow
 permissions:
   contents: read
@@ -68,27 +74,34 @@ jobs:
 
       - name: Install dependencies
         run: uv sync --frozen --extra dev
+        working-directory: ${{ inputs.project-path }}
 
       - name: Additional-install
         if: ${{ inputs.additional-install-command != '' }}
         run: ${{ inputs.additional-install-command }}
+        working-directory: ${{ inputs.project-path }}
 
       - name: Run black
         if: ${{ inputs.run-black }}
         run: uv run --frozen black --check .
+        working-directory: ${{ inputs.project-path }}
 
       - name: Run mypy
         if: ${{ inputs.run-mypy }}
         run: uv run --frozen mypy --disable-error-code=import-untyped .
+        working-directory: ${{ inputs.project-path }}
 
       - name: Run ruff
         if: ${{ inputs.run-ruff }}
         run: uv run --frozen ruff check .
+        working-directory: ${{ inputs.project-path }}
 
       - name: Run isort
         if: ${{ inputs.run-isort }}
         run: uv run --frozen isort --check .
+        working-directory: ${{ inputs.project-path }}
 
       - name: Test with pytest
         run: uv run --frozen pytest
+        working-directory: ${{ inputs.project-path }}
         env: ${{ fromJSON(inputs.test-env) }}


### PR DESCRIPTION
## Summary
- Add optional `project-path` input to `test_and_lint_python_package.yml` reusable workflow
- Defaults to `.` (repo root), so existing callers are unaffected
- Sets `working-directory` on all `run:` steps so repos with `pyproject.toml` in a subdirectory can use this workflow

Needed by sara-fence-detection, which moved `pyproject.toml` from root to `sara_fence_detection/pyproject.toml`.