### PR TITLE
Add reusable migration and database update workflows

### DIFF
--- a/.github/workflows/database_update_orchestration.yml
+++ b/.github/workflows/database_update_orchestration.yml
@@ -1,0 +1,108 @@
+name: Database update orchestration
+
+on:
+  workflow_call:
+    outputs:
+      approved:
+        description: "Whether the PR was approved and migrations should run"
+        value: ${{ jobs.get_review_state.outputs.review_approved }}
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  base_check:
+    if: |
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/UpdateDatabase'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    outputs:
+      eyes_id: ${{ fromJson(steps.eyes.outputs.data).id }}
+    steps:
+      - name: React to comment
+        uses: octokit/request-action@b91aabaa861c777dcdb14e2387e30eddf04619ae #v3
+        id: eyes
+        with:
+          route: POST /repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions
+          content: "eyes"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  get_review_state:
+    needs: base_check
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      review_approved: ${{ contains(fromJson(steps.get.outputs.data).*.state, 'APPROVED') }}
+      eyes_id: ${{ needs.base_check.outputs.eyes_id }}
+    steps:
+      - uses: octokit/request-action@b91aabaa861c777dcdb14e2387e30eddf04619ae #v3
+        id: get
+        with:
+          route: GET /repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}/reviews
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  if_not_approved_then_stop:
+    needs: get_review_state
+    if: ${{ needs.get_review_state.outputs.review_approved == 'false' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Remove eyes reaction
+        uses: octokit/request-action@b91aabaa861c777dcdb14e2387e30eddf04619ae #v3
+        with:
+          route: DELETE /repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions/${{ needs.get_review_state.outputs.eyes_id }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: React to comment
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 #v5
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: confused, -1
+
+      - name: Add comment
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 #v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            :no_entry: Cannot update database until the Pull Request is approved! :no_entry:
+
+  database_update_start:
+    needs: get_review_state
+    if: ${{ needs.get_review_state.outputs.review_approved == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Remove eyes reaction
+        uses: octokit/request-action@b91aabaa861c777dcdb14e2387e30eddf04619ae #v3
+        with:
+          route: DELETE /repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions/${{ needs.get_review_state.outputs.eyes_id }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: React to comment
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 #v5
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: rocket, +1
+
+      - name: Add comment
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 #v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            :eyes: Running migration command... :eyes:

--- a/.github/workflows/database_update_orchestration.yml
+++ b/.github/workflows/database_update_orchestration.yml
@@ -6,6 +6,9 @@ on:
       approved:
         description: "Whether the PR was approved and migrations should run"
         value: ${{ jobs.get_review_state.outputs.review_approved }}
+      pr_head_sha:
+        description: "The PR head commit SHA captured at approval time"
+        value: ${{ jobs.database_update_start.outputs.pr_head_sha }}
 
 permissions:
   contents: read
@@ -85,7 +88,17 @@ jobs:
     permissions:
       pull-requests: write
       issues: write
+    outputs:
+      pr_head_sha: ${{ steps.pr_sha.outputs.pr_head_sha }}
     steps:
+      - name: Capture PR head SHA
+        id: pr_sha
+        run: |
+          PR_SHA=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefOid -q ".headRefOid")
+          echo "pr_head_sha=$PR_SHA" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Remove eyes reaction
         uses: octokit/request-action@b91aabaa861c777dcdb14e2387e30eddf04619ae #v3
         with:

--- a/.github/workflows/migration_actions.yml
+++ b/.github/workflows/migration_actions.yml
@@ -7,12 +7,8 @@ on:
         description: "The workflow run ID from stage one (migration_checks) to download artifacts from"
         required: true
         type: string
-      possible_migration_message:
-        description: "Comment body posted when database files change but no migrations are detected"
-        required: true
-        type: string
-      migration_reminder:
-        description: "Comment body posted when migration files are detected"
+      migration_docs_url:
+        description: "URL to the repository's migration documentation"
         required: true
         type: string
 
@@ -64,7 +60,10 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ needs.download.outputs.pr_number }}
-          body: ${{ inputs.possible_migration_message }}
+          body: |
+            :bell: Changes in database files detected :bell:
+            Do these changes require **adding new migrations**? :thinking: In that case follow [these steps](${{ inputs.migration_docs_url }}).
+            If you are uncertain, ask a database admin on the team :smile:
 
   notify_migration_changes:
     needs: download
@@ -84,7 +83,9 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ needs.download.outputs.pr_number }}
-          body: ${{ inputs.migration_reminder }}
+          body: |
+            :bell: Migrations changes detected :bell:
+            :mega: Remember to comment "/UpdateDatabase" after review approval for migrations to take effect!
 
       - name: Add label
         run: gh pr edit "$NUMBER" --add-label "database-change"

--- a/.github/workflows/migration_actions.yml
+++ b/.github/workflows/migration_actions.yml
@@ -1,0 +1,113 @@
+name: Migration actions
+
+on:
+  workflow_call:
+    inputs:
+      stage_one_workflow_run_id:
+        description: "The workflow run ID from stage one (migration_checks) to download artifacts from"
+        required: true
+        type: string
+      possible_migration_message:
+        description: "Comment body posted when database files change but no migrations are detected"
+        required: true
+        type: string
+      migration_reminder:
+        description: "Comment body posted when migration files are detected"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+env:
+  update_success_message: ":sparkles: Successfully ran migration command! :sparkles:"
+
+jobs:
+  download:
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.read.outputs.pr_number }}
+      database_changed: ${{ steps.read.outputs.database_changed }}
+      migrations_changed: ${{ steps.read.outputs.migrations_changed }}
+    steps:
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@20319c5641d495c8a52e688b7dc5fada6c3c9b28 #v8
+        with:
+          run_id: ${{ inputs.stage_one_workflow_run_id }}
+          name: migration-check-results
+
+      - name: Read results
+        id: read
+        run: |
+          cat migration-check-results.json
+          echo "pr_number=$(jq -r '.pr_number' migration-check-results.json)" >> $GITHUB_OUTPUT
+          echo "database_changed=$(jq -r '.database_changed' migration-check-results.json)" >> $GITHUB_OUTPUT
+          echo "migrations_changed=$(jq -r '.migrations_changed' migration-check-results.json)" >> $GITHUB_OUTPUT
+
+  notify_possible_migration:
+    needs: download
+    if: needs.download.outputs.database_changed == 'true' && needs.download.outputs.migrations_changed != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for previous comment
+        id: notify_comment_search
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad #v4
+        with:
+          issue-number: ${{ needs.download.outputs.pr_number }}
+          body-includes: Changes in database
+
+      - name: Add comment if not already posted
+        if: ${{ !steps.notify_comment_search.outputs.comment-body }}
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 #v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ needs.download.outputs.pr_number }}
+          body: ${{ inputs.possible_migration_message }}
+
+  notify_migration_changes:
+    needs: download
+    if: needs.download.outputs.migrations_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for previous comment
+        id: notify_comment_search
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad #v4
+        with:
+          issue-number: ${{ needs.download.outputs.pr_number }}
+          body-includes: Migrations changes detected
+
+      - name: Add comment if not already posted
+        if: ${{ !steps.notify_comment_search.outputs.comment-body }}
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 #v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ needs.download.outputs.pr_number }}
+          body: ${{ inputs.migration_reminder }}
+
+      - name: Add label
+        run: gh pr edit "$NUMBER" --add-label "database-change"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ needs.download.outputs.pr_number }}
+
+  verify_migrations:
+    needs: download
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for database success comment
+        if: needs.download.outputs.migrations_changed == 'true'
+        id: database_comment_search
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad #v4
+        with:
+          issue-number: ${{ needs.download.outputs.pr_number }}
+          body-includes: ${{ env.update_success_message }}
+          comment-author: github-actions[bot]
+
+      - name: Fail if database not updated
+        if: >-
+          needs.download.outputs.migrations_changed == 'true' &&
+          !steps.database_comment_search.outputs.comment-body
+        run: exit 1

--- a/.github/workflows/migration_checks.yml
+++ b/.github/workflows/migration_checks.yml
@@ -1,0 +1,51 @@
+name: Migration checks
+
+on:
+  workflow_call:
+    inputs:
+      database_paths:
+        description: "Glob pattern for database model files (e.g. 'backend/api/Database/**')"
+        required: true
+        type: string
+      migrations_paths:
+        description: "Glob pattern for migration files (e.g. 'backend/api/Migrations/**')"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  check_changes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+
+      - name: Get changed files in database folder
+        id: database_changes
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 #v47
+        with:
+          files: ${{ inputs.database_paths }}
+
+      - name: Get changed files in migrations folder
+        id: migration_changes
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 #v47
+        with:
+          files: ${{ inputs.migrations_paths }}
+
+      - name: Write results
+        run: |
+          cat <<EOF > migration-check-results.json
+          {
+            "pr_number": ${{ github.event.pull_request.number }},
+            "database_changed": "${{ steps.database_changes.outputs.any_changed }}",
+            "migrations_changed": "${{ steps.migration_changes.outputs.any_changed }}"
+          }
+          EOF
+
+      - name: Upload results
+        uses: actions/upload-artifact@ea165f8d65b6db9b8a4d0d969e6e21c0ff4c0121 #v4
+        with:
+          name: migration-check-results
+          path: migration-check-results.json

--- a/.github/workflows/run_alembic_migrations.yml
+++ b/.github/workflows/run_alembic_migrations.yml
@@ -3,11 +3,11 @@ name: Run alembic migrations
 on:
   workflow_call:
     inputs:
-      pull_request_checkout:
-        description: "Whether to checkout the PR head branch"
+      pr_head_sha:
+        description: "PR head commit SHA to checkout (set to skip default ref checkout)"
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: ""
       environment:
         description: "Target environment (Development, Staging, Production)"
         required: true
@@ -40,23 +40,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
         with:
-          ref: ${{ inputs.checkout_ref }}
-
-      - name: Fetch PR head SHA
-        if: ${{ inputs.pull_request_checkout }}
-        id: pr_head_sha
-        run: |
-          PR_SHA=$(gh pr view ${{ github.event.issue.number }} --json headRefOid -q ".headRefOid")
-          echo "pr_head_sha=$PR_SHA" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout pull request by SHA
-        if: ${{ inputs.pull_request_checkout }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ steps.pr_head_sha.outputs.pr_head_sha }}
+          ref: ${{ inputs.pr_head_sha || inputs.checkout_ref }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6

--- a/.github/workflows/run_alembic_migrations.yml
+++ b/.github/workflows/run_alembic_migrations.yml
@@ -1,0 +1,76 @@
+name: Run alembic migrations
+
+on:
+  workflow_call:
+    inputs:
+      pull_request_checkout:
+        description: "Whether to checkout the PR head branch"
+        required: false
+        type: boolean
+        default: false
+      environment:
+        description: "Target environment (Development, Staging, Production)"
+        required: true
+        type: string
+      checkout_ref:
+        description: "Git ref to checkout (tag, branch, or SHA)"
+        required: false
+        type: string
+        default: "main"
+      python_version:
+        description: "Python version"
+        required: false
+        type: string
+        default: "3.14"
+    secrets:
+      client_id:
+        required: true
+      client_secret:
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  run_migrations:
+    environment: ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        with:
+          ref: ${{ inputs.checkout_ref }}
+
+      - name: Fetch PR head SHA
+        if: ${{ inputs.pull_request_checkout }}
+        id: pr_head_sha
+        run: |
+          PR_SHA=$(gh pr view ${{ github.event.issue.number }} --json headRefOid -q ".headRefOid")
+          echo "pr_head_sha=$PR_SHA" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout pull request by SHA
+        if: ${{ inputs.pull_request_checkout }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ steps.pr_head_sha.outputs.pr_head_sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6
+        with:
+          python-version: ${{ inputs.python_version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Update database
+        run: alembic upgrade head
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.client_id }}
+          AZURE_CLIENT_SECRET: ${{ secrets.client_secret }}
+          AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}

--- a/.github/workflows/run_dotnet_migrations.yml
+++ b/.github/workflows/run_dotnet_migrations.yml
@@ -3,11 +3,11 @@ name: Run dotnet migrations
 on:
   workflow_call:
     inputs:
-      pull_request_checkout:
-        description: "Whether to checkout the PR head branch"
+      pr_head_sha:
+        description: "PR head commit SHA to checkout (set to skip default ref checkout)"
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: ""
       environment:
         description: "Target environment (Development, Staging, Production)"
         required: true
@@ -52,23 +52,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
         with:
-          ref: ${{ inputs.checkout_ref }}
-
-      - name: Fetch PR head SHA
-        if: ${{ inputs.pull_request_checkout }}
-        id: pr_head_sha
-        run: |
-          PR_SHA=$(gh pr view ${{ github.event.issue.number }} --json headRefOid -q ".headRefOid")
-          echo "pr_head_sha=$PR_SHA" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout pull request by SHA
-        if: ${{ inputs.pull_request_checkout }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ steps.pr_head_sha.outputs.pr_head_sha }}
+          ref: ${{ inputs.pr_head_sha || inputs.checkout_ref }}
 
       - name: Set up .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5

--- a/.github/workflows/run_dotnet_migrations.yml
+++ b/.github/workflows/run_dotnet_migrations.yml
@@ -1,0 +1,90 @@
+name: Run dotnet migrations
+
+on:
+  workflow_call:
+    inputs:
+      pull_request_checkout:
+        description: "Whether to checkout the PR head branch"
+        required: false
+        type: boolean
+        default: false
+      environment:
+        description: "Target environment (Development, Staging, Production)"
+        required: true
+        type: string
+      checkout_ref:
+        description: "Git ref to checkout (tag, branch, or SHA)"
+        required: false
+        type: string
+        default: "main"
+      working_directory:
+        description: "Directory containing the .NET project"
+        required: true
+        type: string
+      dotnet_version:
+        description: ".NET SDK version"
+        required: false
+        type: string
+        default: "10.0.x"
+      dotnet_ef_version:
+        description: "dotnet-ef tool version"
+        required: false
+        type: string
+        default: "10.0.*"
+    secrets:
+      client_id:
+        required: true
+      client_secret:
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  run_migrations:
+    environment: ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        with:
+          ref: ${{ inputs.checkout_ref }}
+
+      - name: Fetch PR head SHA
+        if: ${{ inputs.pull_request_checkout }}
+        id: pr_head_sha
+        run: |
+          PR_SHA=$(gh pr view ${{ github.event.issue.number }} --json headRefOid -q ".headRefOid")
+          echo "pr_head_sha=$PR_SHA" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout pull request by SHA
+        if: ${{ inputs.pull_request_checkout }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ steps.pr_head_sha.outputs.pr_head_sha }}
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5
+        with:
+          dotnet-version: ${{ inputs.dotnet_version }}
+
+      - name: Build project and dependencies
+        run: dotnet build
+
+      - name: Install dotnet ef tool
+        run: dotnet tool install -g dotnet-ef --version ${{ inputs.dotnet_ef_version }}
+
+      - name: Update database
+        run: dotnet ef database update --no-build --verbose
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.client_id }}
+          AZURE_CLIENT_SECRET: ${{ secrets.client_secret }}
+          AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+          ASPNETCORE_ENVIRONMENT: ${{ vars.AspNetEnvironment }}


### PR DESCRIPTION
## Summary

- Add five reusable workflows to consolidate database migration management across flotilla, sara, and isar
- Provides a two-stage `pull_request` + `workflow_run` pattern for migration checks and notifications, replacing per-repo implementations
- Includes parameterized migration runners for both .NET EF Core and Python Alembic

## New workflows

| Workflow | Purpose |
|---|---|
| `migration_checks.yml` | Detects changes in database model and migration files, uploads results as artifact |
| `migration_actions.yml` | Posts reminder comments, adds `database-change` label, verifies `/UpdateDatabase` was run |
| `database_update_orchestration.yml` | Handles `/UpdateDatabase` PR comment: approval check, emoji reactions, status comments |
| `run_dotnet_migrations.yml` | Executes .NET EF Core migrations (`dotnet ef database update`) with parameterized directory, version, and environment |
| `run_alembic_migrations.yml` | Executes Python Alembic migrations (`alembic upgrade head`) with parameterized Python version and environment |

## Consuming repositories

The following repos will adopt these workflows (PRs to follow once this is merged):
- [equinor/flotilla](https://github.com/equinor/flotilla)
- [equinor/sara](https://github.com/equinor/sara)
- [equinor/isar](https://github.com/equinor/isar)

## Notes

- This PR must be merged before the consuming repository PRs, as they reference `equinor/armada/.github/workflows/...@main`
- The `migration_actions` workflow uses `dawidd6/action-download-artifact` (v8) to download artifacts across workflow runs
- All existing action SHAs are preserved from the current per-repo implementations
- Standardizes on `gh pr edit --add-label` for labeling (replacing `actions-ecosystem/action-add-labels` used in sara)
- Standardizes on the two-step SHA-based PR checkout method across both migration runners

## Related

- Part of equinor/robotics-infrastructure#945