### PR TITLE
Fix action SHA typos in migration workflows

### DIFF
--- a/.github/workflows/migration_actions.yml
+++ b/.github/workflows/migration_actions.yml
@@ -29,7 +29,7 @@ jobs:
       migrations_changed: ${{ steps.read.outputs.migrations_changed }}
     steps:
       - name: Download artifact
-        uses: dawidd6/action-download-artifact@20319c5641d495c8a52e688b7dc5fada6c3c9b28 #v8
+        uses: dawidd6/action-download-artifact@20319c5641d495c8a52e688b7dc5fada6c3a9fbc #v8
         with:
           run_id: ${{ inputs.stage_one_workflow_run_id }}
           name: migration-check-results

--- a/.github/workflows/migration_checks.yml
+++ b/.github/workflows/migration_checks.yml
@@ -45,7 +45,7 @@ jobs:
           EOF
 
       - name: Upload results
-        uses: actions/upload-artifact@ea165f8d65b6db9b8a4d0d969e6e21c0ff4c0121 #v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
         with:
           name: migration-check-results
           path: migration-check-results.json


### PR DESCRIPTION
## Summary

- Fix incorrect commit SHAs for two pinned GitHub Actions introduced in #39

## Fixes

| Workflow | Action | Incorrect SHA | Correct SHA |
|---|---|---|---|
| `migration_checks.yml` | `actions/upload-artifact` (#v4) | `...6db9b8a4d0d969e6e21c0ff4c0121` | `...6e75b540449e92b4886f43607fa02` |
| `migration_actions.yml` | `dawidd6/action-download-artifact` (#v8) | `...6c3c9b28` | `...6c3a9fbc` |

Both were likely copy-paste typos — the first ~14 characters matched the real SHAs, causing the errors to go unnoticed until CI attempted to resolve them.