### PR TITLE
Update Node.js 20 actions to Node.js 24 versions

### DIFF
--- a/.github/workflows/notify_migrations_on_pr.yml
+++ b/.github/workflows/notify_migrations_on_pr.yml
@@ -26,10 +26,11 @@ jobs:
       migrations_changed: ${{ steps.read.outputs.migrations_changed }}
     steps:
       - name: Download artifact
-        uses: dawidd6/action-download-artifact@20319c5641d495c8a52e688b7dc5fada6c3a9fbc #v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8
         with:
-          run_id: ${{ inputs.stage_one_workflow_run_id }}
+          run-id: ${{ inputs.stage_one_workflow_run_id }}
           name: migration-check-results
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read results
         id: read

--- a/.github/workflows/verify_migrations.yml
+++ b/.github/workflows/verify_migrations.yml
@@ -52,7 +52,7 @@ jobs:
           EOF
 
       - name: Upload results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7
         with:
           name: migration-check-results
           path: migration-check-results.json


### PR DESCRIPTION
## Summary

- Update `actions/upload-artifact` from v4 (node20) to v7 (node24)
- Replace `dawidd6/action-download-artifact` (v8, node20) with official `actions/download-artifact` (v8, node24)

## Why

Node.js 20 actions are deprecated and will be forced to run on Node.js 24 starting June 2, 2026. Node.js 20 will be removed from runners on September 16, 2026.

## Changes

- `verify_migrations.yml`: `actions/upload-artifact` v4 → v7
- `notify_migrations_on_pr.yml`: `dawidd6/action-download-artifact` → `actions/download-artifact@v8` with `run-id` (hyphenated) and explicit `github-token`

## Breaking changes

None. The official `actions/download-artifact@v8` supports `run-id` for cross-workflow artifact downloads, which is what we use. The `github-token` input is required when downloading from a different workflow run.