### PR TITLE
Add reusable workflow for frontend linting and testing

### DIFF
--- a/.github/workflows/lint_frontend_package.yml
+++ b/.github/workflows/lint_frontend_package.yml
@@ -27,12 +27,6 @@ on:
         type: boolean
         default: true
 
-      eslint-target:
-        description: "Target path for eslint"
-        required: false
-        type: string
-        default: "."
-
       run-build:
         description: "Run npm build"
         required: false
@@ -64,8 +58,12 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6
         with:
           node-version: ${{ matrix.node-version }}
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+      - name: Install modules
+        run: npm ci
       - name: Run Prettier
-        run: npx prettier --check .
+        run: npm run prettier_check
 
   run_eslint:
     if: ${{ inputs.run-eslint }}
@@ -87,7 +85,7 @@ jobs:
       - name: Install modules
         run: npm ci
       - name: Run ESLint
-        run: npx eslint ${{ inputs.eslint-target }}
+        run: npm run lint
 
   build:
     if: ${{ inputs.run-build }}

--- a/.github/workflows/lint_frontend_package.yml
+++ b/.github/workflows/lint_frontend_package.yml
@@ -1,4 +1,4 @@
-name: Test and lint frontend package
+name: Lint frontend package
 
 on:
   workflow_call:

--- a/.github/workflows/lint_frontend_package.yml
+++ b/.github/workflows/lint_frontend_package.yml
@@ -13,7 +13,7 @@ on:
         description: "Path to the frontend project directory"
         required: false
         type: string
-        default: "frontend"
+        default: "."
 
       run-prettier:
         description: "Run prettier format check"

--- a/.github/workflows/test_and_lint_frontend_package.yml
+++ b/.github/workflows/test_and_lint_frontend_package.yml
@@ -1,0 +1,169 @@
+name: Test and lint frontend package
+
+on:
+  workflow_call:
+    inputs:
+      node-versions:
+        description: "JSON list of node versions"
+        required: false
+        type: string
+        default: '["20.x"]'
+
+      working-directory:
+        description: "Path to the frontend project directory"
+        required: false
+        type: string
+        default: "frontend"
+
+      run-prettier:
+        description: "Run prettier format check"
+        required: false
+        type: boolean
+        default: true
+
+      run-eslint:
+        description: "Run eslint linting"
+        required: false
+        type: boolean
+        default: true
+
+      eslint-target:
+        description: "Target path for eslint"
+        required: false
+        type: string
+        default: "."
+
+      run-build:
+        description: "Run npm build"
+        required: false
+        type: boolean
+        default: true
+
+      run-tests:
+        description: "Run npm test"
+        required: false
+        type: boolean
+        default: false
+
+      test-env:
+        description: "JSON object of environment variables provided for test run"
+        required: false
+        type: string
+        default: '{}'
+
+      run-unused-exports:
+        description: "Run ts-unused-exports check"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  check_formatting:
+    if: ${{ inputs.run-prettier }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ${{ fromJSON(inputs.node-versions) }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f #v6
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Run Prettier
+        run: npx prettier --check .
+
+  run_eslint:
+    if: ${{ inputs.run-eslint }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ${{ fromJSON(inputs.node-versions) }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f #v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+      - name: Install modules
+        run: npm ci
+      - name: Run ESLint
+        run: npx eslint ${{ inputs.eslint-target }}
+
+  build:
+    if: ${{ inputs.run-build }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ${{ fromJSON(inputs.node-versions) }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f #v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+      - name: Install modules
+        run: npm ci
+      - name: Build
+        run: npm run build
+
+  test:
+    if: ${{ inputs.run-tests }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ${{ fromJSON(inputs.node-versions) }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f #v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+      - name: Install modules
+        run: npm ci
+      - name: Run tests
+        run: npm test
+        env: ${{ fromJSON(inputs.test-env) }}
+
+  check_exports:
+    if: ${{ inputs.run-unused-exports }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ${{ fromJSON(inputs.node-versions) }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f #v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+      - name: Install modules
+        run: npm ci
+      - name: Run Unused Exports Check
+        run: ./node_modules/.bin/ts-unused-exports tsconfig.json

--- a/.github/workflows/test_and_lint_frontend_package.yml
+++ b/.github/workflows/test_and_lint_frontend_package.yml
@@ -7,7 +7,7 @@ on:
         description: "JSON list of node versions"
         required: false
         type: string
-        default: '["20.x"]'
+        default: '["24.x"]'
 
       working-directory:
         description: "Path to the frontend project directory"
@@ -39,18 +39,6 @@ on:
         type: boolean
         default: true
 
-      run-tests:
-        description: "Run npm test"
-        required: false
-        type: boolean
-        default: false
-
-      test-env:
-        description: "JSON object of environment variables provided for test run"
-        required: false
-        type: string
-        default: '{}'
-
       run-unused-exports:
         description: "Run ts-unused-exports check"
         required: false
@@ -73,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f #v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6
         with:
           node-version: ${{ matrix.node-version }}
       - name: Run Prettier
@@ -91,7 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f #v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
@@ -113,7 +101,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f #v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
@@ -122,29 +110,6 @@ jobs:
         run: npm ci
       - name: Build
         run: npm run build
-
-  test:
-    if: ${{ inputs.run-tests }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: ${{ fromJSON(inputs.node-versions) }}
-    defaults:
-      run:
-        working-directory: ${{ inputs.working-directory }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f #v6
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: "npm"
-          cache-dependency-path: "**/package-lock.json"
-      - name: Install modules
-        run: npm ci
-      - name: Run tests
-        run: npm test
-        env: ${{ fromJSON(inputs.test-env) }}
 
   check_exports:
     if: ${{ inputs.run-unused-exports }}
@@ -158,7 +123,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f #v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"


### PR DESCRIPTION
## Summary

Adds a new reusable workflow `test_and_lint_frontend_package.yml` for frontend projects, following the same pattern as `test_and_lint_python_package.yml`.

The workflow supports configurable parallel jobs for:
- Prettier format checking
- ESLint linting (with configurable target)
- npm build
- npm test (with configurable env vars)
- ts-unused-exports check

All jobs are individually toggleable via boolean inputs. This enables flotilla and pointilla_maps (and future frontend repos) to share a single CI definition.

Related: equinor/pointilla_maps#34