### PR TITLE
Add run-tests input to reusable test workflow

### DIFF
--- a/.github/workflows/test_and_lint_python_package.yml
+++ b/.github/workflows/test_and_lint_python_package.yml
@@ -39,6 +39,12 @@ on:
         type: boolean
         default: true
 
+      run-tests:
+        description: "Run pytest"
+        required: false
+        type: boolean
+        default: true
+
       additional-install-command:
         description: "Command to run before uv sync (e.g. installing PyTorch from CPU index)"
         required: false
@@ -90,5 +96,6 @@ jobs:
         run: uv run --frozen isort --check .
 
       - name: Test with pytest
+        if: ${{ inputs.run-tests }}
         run: uv run --frozen pytest
         env: ${{ fromJSON(inputs.test-env) }}


### PR DESCRIPTION
## Summary

- Add `run-tests` boolean input (default `true`) to the reusable test and lint workflow
- Allows callers to use the workflow for linting only, while running tests in a separate job that has access to secrets

This is needed by isar-anymal (equinor/isar-anymal#428) which requires secret access during tests to download private test data from Azure Blob Storage.