### PR TITLE
Boot multi-robot test fixture with robots already at home

### DIFF
--- a/robotics_integration_tests/conftest.py
+++ b/robotics_integration_tests/conftest.py
@@ -450,7 +450,14 @@ def armada_with_multiple_robots(armada_without_robots: Armada):
     """Spin up four ISAR robot containers with different mission/return-home
     behaviour to test parallel multi-robot scenarios.
 
-    Robot configurations:
+    All robots are configured with ``ROBOT_SHOULD_START_AT_HOME=true`` so they
+    boot directly into ISAR's ``Home`` state, skipping the bootstrap
+    return-home cycle. Without this, robots configured to fail return-home
+    would race the test: the boot return-home would fail and put them into
+    ``InterventionNeeded`` before the test had a chance to schedule the echo
+    mission, making the mission un-dispatchable.
+
+    Robot configurations (mission and post-mission return-home outcomes):
         1. MissionOkThenHome – mission succeeds, returns home successfully
         2. MissionOkThenLost – mission succeeds, fails to return home
         3. MissionFailThenHome – mission fails, returns home successfully
@@ -475,24 +482,28 @@ def armada_with_multiple_robots(armada_without_robots: Armada):
             "alias": "isar_mission_ok_then_home",
             "should_fail_normal_task": False,
             "should_fail_return_home": False,
+            "should_start_at_home": True,
         },
         {
             "name": "MissionOkThenLost",
             "alias": "isar_mission_ok_then_lost",
             "should_fail_normal_task": False,
             "should_fail_return_home": True,
+            "should_start_at_home": True,
         },
         {
             "name": "MissionFailThenHome",
             "alias": "isar_mission_fail_then_home",
             "should_fail_normal_task": True,
             "should_fail_return_home": False,
+            "should_start_at_home": True,
         },
         {
             "name": "MissionFailThenLost",
             "alias": "isar_mission_fail_then_lost",
             "should_fail_normal_task": True,
             "should_fail_return_home": True,
+            "should_start_at_home": True,
         },
     ]
 
@@ -516,6 +527,7 @@ def armada_with_multiple_robots(armada_without_robots: Armada):
                     should_fail_normal_task=cfg["should_fail_normal_task"],
                     should_fail_return_home=cfg["should_fail_return_home"],
                     return_home_retry_limit=1,
+                    should_start_at_home=cfg["should_start_at_home"],
                     test_id=armada.test_id,
                 )
             )

--- a/robotics_integration_tests/custom_containers/isar.py
+++ b/robotics_integration_tests/custom_containers/isar.py
@@ -37,6 +37,7 @@ def create_isar_robot_container(
     should_fail_normal_task: bool = False,
     should_fail_return_home: bool = False,
     return_home_retry_limit: int = 5,
+    should_start_at_home: bool = False,
     test_id: str = "",
 ) -> StreamLoggingDockerContainer:
 
@@ -84,6 +85,7 @@ def create_isar_robot_container(
         )
         .with_env("ROBOT_MISSION_SIMULATION_MISSION_COMPLETION_DELAY", 5)
         .with_env("ISAR_RETURN_HOME_RETRY_LIMIT", return_home_retry_limit)
+        .with_env("ROBOT_SHOULD_START_AT_HOME", str(should_start_at_home).lower())
         .with_env("ISAR_ISAR_ID", str(uuid.uuid4()))
     )
     return container


### PR DESCRIPTION
## Summary

Configures the `armada_with_multiple_robots` fixture's four simulated `isar-robot` instances to boot directly into ISAR's `Home` state (via the new `ROBOT_SHOULD_START_AT_HOME=true` env var) instead of `Available`. This eliminates a boot-time race that makes `test_multiple_robots_with_different_outcomes` flaky in downstream CI.

## Why

In the current fixture, robots configured with `should_fail_return_home=True` (i.e. `MissionOkThenLost` and `MissionFailThenLost`) start in `Available`, which causes ISAR to immediately attempt a bootstrap return-home cycle. With `ISAR_RETURN_HOME_RETRY_LIMIT=1`, that cycle quickly exhausts retries and lands the robot in `InterventionNeeded` — sometimes *before* the test gets to schedule its echo mission. When this happens, the queued mission run can never be dispatched and the test times out waiting for it.

This race is the root cause of the flake observed in [equinor/flotilla actions run #25423080464](https://github.com/equinor/flotilla/actions/runs/25423080464/job/74569703992) (mission run `679bfbaf-042a-4832-8be6-404c2ed079c9`, robot `MissionOkThenLost`, ISAR rejection: `Conflict - Robot is not home, robot standing still, awaiting next mission or returning home - State: States.InterventionNeeded`).

By having the robots boot directly into `Home`, the bootstrap return-home cycle is skipped entirely. The `should_fail_return_home` configuration still takes effect *after* the test's own mission runs (which is the intent of the test).

## Changes

- `robotics_integration_tests/custom_containers/isar.py`: new `should_start_at_home: bool = False` parameter on `create_isar_robot_container`, passed through as the `ROBOT_SHOULD_START_AT_HOME` env var.
- `robotics_integration_tests/conftest.py`: in `armada_with_multiple_robots`, set `should_start_at_home=True` for all four robot configs and thread the value through to `create_isar_robot_container`. Updated docstring to explain the rationale.

## Compatibility

- The new parameter defaults to `False`, so other tests/fixtures using `create_isar_robot_container` are unaffected.
- The `ROBOT_SHOULD_START_AT_HOME` setting in `isar-robot` (added in [equinor/isar-robot#379](https://github.com/equinor/isar-robot/pull/379), merged) also defaults to `False`, so unknown env-var values are not an issue.
- Until the next `isar-robot` GitHub release publishes a new `:latest` tag, this fixture change is effectively a no-op (the env var will be unrecognized by the older image and ignored, since the fixture sets `False` semantically when the setting is absent — wait, actually it sets `true`/`false`; pydantic-settings on the older image will simply not have that field, so the env var is dropped silently). Once the new release lands, the fixture will take effect automatically.

## Test plan

- Pulled the post-merge `ghcr.io/equinor/isar-robot:dev` image and confirmed it exposes the new setting (`SHOULD_START_AT_HOME: False` by default).
- Ran the targeted test twice locally with `ISAR_ROBOT_IMAGE=ghcr.io/equinor/isar-robot:dev`:
  - Run 1: `1 passed in 225.36s`
  - Run 2: `1 passed in 234.62s`
- No other tests modified.

## Related

- Depends on: equinor/isar-robot#379 (merged) — adds the `SHOULD_START_AT_HOME` setting.
- Fixes flake observed in: equinor/flotilla CI run linked above.