### PR TITLE
Add shared Copilot configuration for Flotilla-SARA repos

### DIFF
--- a/.github/copilot/README.md
+++ b/.github/copilot/README.md
@@ -1,0 +1,69 @@
+# Shared Copilot configuration for the Flotilla–SARA system
+
+This directory holds the **canonical** GitHub Copilot configuration shared across
+the Flotilla–SARA repositories (e.g. `flotilla`, `isar`, `isar-robot`,
+`isar-anymal`, `isar-taurob`, `sara`, `sara-*`, `robotics-infrastructure`,
+`analytics-infrastructure`, `eq_robot_utility_scripts`).
+
+Copilot only reads files that physically exist inside the repo it is operating
+on. To avoid hand-maintaining N copies, this repo (`armada`) is the single
+source of truth, and consuming repos receive synced copies stamped with the
+source commit SHA.
+
+## Contents
+
+```
+.github/copilot/
+├── README.md                        # this file
+├── shared-instructions.md           # block injected into each consumer's
+│                                    # .github/copilot-instructions.md
+└── prompts/
+    └── review-pr.prompt.md          # full PR-review prompt for VS Code / CLI
+```
+
+A small bash script `armada/scripts/sync-copilot.sh` distributes these files
+into a target repo.
+
+## How to consume in another repo
+
+From an `armada` checkout, run:
+
+```bash
+./scripts/sync-copilot.sh <path-to-target-repo>
+```
+
+The script will:
+
+1. Copy `prompts/review-pr.prompt.md` to
+   `<target>/.github/prompts/review-pr.prompt.md` with an
+   `<!-- AUTO-GENERATED from equinor/armada@<sha> -->` header.
+2. Update (or create) `<target>/.github/copilot-instructions.md`, replacing the
+   block between
+
+   ```
+   <!-- BEGIN SYNCED FROM equinor/armada@<sha> -->
+   ...
+   <!-- END SYNCED -->
+   ```
+
+   with the current contents of `shared-instructions.md`. Any content **outside**
+   those markers is preserved verbatim.
+
+The script is idempotent: running it again with a newer `armada` checkout
+re-stamps the SHA and refreshes the synced block in place.
+
+## Editing rules
+
+- **Edit `shared-instructions.md` and `prompts/review-pr.prompt.md` here, in
+  `armada`.** Never hand-edit the synced copies in consuming repos — they will
+  be overwritten on the next sync.
+- Repo-specific guidance belongs in the consumer's own
+  `.github/copilot-instructions.md`, *outside* the synced markers.
+- Prefer additive changes; consumers may rely on the existing structure.
+
+## Why `armada`?
+
+`armada` is the integration-test harness that already orchestrates the whole
+Flotilla–SARA system (it runs container images of `flotilla`, `isar-robot` and
+`sara` together), so it is the natural home for cross-system knowledge and
+review heuristics.

--- a/.github/copilot/prompts/review-pr.prompt.md
+++ b/.github/copilot/prompts/review-pr.prompt.md
@@ -1,0 +1,156 @@
+---
+mode: agent
+description: Review a pull request in a Flotilla–SARA repository.
+---
+
+# Review a pull request
+
+You are reviewing a pull request in a repository that is part of the Equinor
+Flotilla–SARA robotics system. Be direct, technical, and concise. No emojis.
+Cite every finding as `path:line`.
+
+## 1. Determine what to review (auto-detect)
+
+Pick the **first** of the following that applies:
+
+1. **Explicit PR provided by the user.** If the user supplies a PR number, URL,
+   or branch name, use the GitHub CLI:
+
+   ```bash
+   gh pr view <pr>   --json number,title,body,headRefName,baseRefName,author,files,additions,deletions,url
+   gh pr diff <pr>
+   ```
+
+2. **Current branch is associated with an open PR.** Try:
+
+   ```bash
+   gh pr view --json number,title,body,headRefName,baseRefName,author,files,additions,deletions,url
+   gh pr diff
+   ```
+
+   If this succeeds, review that PR.
+
+3. **Local branch diff against the default branch.** Determine the default
+   branch — try `gh` first, then fall back to `git`:
+
+   ```bash
+   gh repo view --json defaultBranchRef -q .defaultBranchRef.name \
+     || git symbolic-ref --short refs/remotes/origin/HEAD | sed 's@^origin/@@'
+   ```
+
+   Then review the diff:
+
+   ```bash
+   git fetch origin <default-branch>
+   git diff origin/<default-branch>...HEAD
+   git log --oneline origin/<default-branch>..HEAD
+   ```
+
+If none of these yields a non-empty diff, ask the user which PR or branch to
+review and stop.
+
+## 2. Build context
+
+Before commenting:
+
+- Read the PR description (or, for branch-only review, the commit messages) to
+  understand intent and any linked issues.
+- Skim the changed files in full where the diff is non-trivial — do not review
+  hunks in isolation.
+- Note the repo's role in the Flotilla–SARA system (see
+  `.github/copilot-instructions.md`) so you can reason about cross-repo impact.
+
+## 3. Review checklist
+
+Walk through every item. For each, either record a finding or note that the
+item is satisfied.
+
+1. **Correctness vs. intent.** Does the implementation match what the PR
+   description and linked issues say it should do? Are edge cases and error
+   paths handled?
+
+2. **Cross-repo impact.** Explicitly check whether the diff touches a contract
+   shared with sibling repos:
+
+   - ISAR MQTT message models (`IsarStatus`, `IsarTask`, `IsarMission`,
+     `IsarBattery`, `IsarPressure`, `IsarRobotInfo`, `IsarRobotHeartbeat`,
+     `IsarCloudHealth`, `IsarInspectionResultMessage`, ...).
+   - The ISAR `robot_interface` (Python ABC defined in `isar`, implemented by
+     `isar-robot`, `isar-anymal`, `isar-taurob`).
+   - SARA Argo workflow step contracts (inputs/outputs of
+     `sara-anonymizer`, `sara-constant-level-oiler`, `sara-stid`,
+     `sara-thermal-reading`, `sara-fence-detection`, `sara-timeseries`).
+   - Shared HTTP/REST schemas (`flotilla` ↔ frontend, `flotilla` ↔ `isar`,
+     `sara` ↔ analysis steps).
+   - Deployment manifests under `robotics-infrastructure` or
+     `analytics-infrastructure` (kustomize overlays, ConfigMaps).
+
+   For each affected contract, **name the sibling repo(s) that likely need a
+   coordinated PR** and describe what the matching change should do.
+
+3. **Tests.**
+   - New or changed behaviour is covered by unit or integration tests.
+   - Existing tests are updated where their assumptions changed.
+   - Consider whether `armada` integration tests need to be added or updated
+     (especially when changing flotilla ↔ isar ↔ sara interactions).
+
+4. **Security.**
+   - No secrets, credentials, tokens, certificates, or private endpoints in
+     the diff.
+   - New outbound network calls are justified and documented.
+   - New dependencies are reputable, pinned, and licensed compatibly.
+   - Input validation on any externally-reachable surface.
+
+5. **Backward compatibility.** Public contracts remain compatible, or the PR
+   provides a migration path:
+   - HTTP routes and request/response shapes.
+   - MQTT topic names and payload schemas.
+   - CLI flags and environment variables.
+   - Database schemas (look for missing/incorrect EF Core or Alembic
+     migrations).
+   - Config file keys.
+
+6. **Observability.** Where the change affects runtime behaviour, failure
+   modes, or performance: are logs at appropriate levels added/preserved? Are
+   metrics or traces updated? Are error messages actionable?
+
+7. **Style and conventions.** Code matches the repo's language conventions
+   (C# / TypeScript / Python / Kustomize / Bash) and would pass the repo's
+   lint/format gates (csharpier, prettier, eslint, ruff, black, mypy, etc.) if
+   run locally.
+
+8. **Docs.** README, in-repo docs, or PR template fields are updated when
+   user-visible behaviour or developer workflow changes.
+
+9. **Commits & PR hygiene.** Commit messages follow the repo's convention
+   (typically https://cbea.ms/git-commit/); each commit builds; the PR
+   description explains the *why*, not just the *what*; linked issues present.
+
+## 4. Output
+
+Produce **exactly** these four sections, in this order, in Markdown. Use
+`- _none_` for empty sections. Do not add other top-level sections.
+
+```
+## Summary
+<1–3 sentences: what the PR does and your overall assessment.>
+
+## Blocking
+- <Issue that must be resolved before merge.> — `path:line`
+
+## Suggestions
+- <Non-blocking improvement.> — `path:line`
+
+## Questions
+- <Question for the author that the diff alone cannot answer.>
+```
+
+Rules for the output:
+
+- Be specific. Quote short snippets only when needed for clarity.
+- Prefer concrete suggested changes (a one-line diff or a short code block)
+  over vague advice.
+- When you flag cross-repo impact in **Blocking** or **Suggestions**, name the
+  sibling repo(s) explicitly, e.g. `Coordinated PR likely needed in
+  equinor/flotilla (backend MQTT message model).`
+- Do not restate the entire diff. Do not invent findings to fill sections.

--- a/.github/copilot/shared-instructions.md
+++ b/.github/copilot/shared-instructions.md
@@ -1,0 +1,53 @@
+## Flotilla–SARA system context
+
+This repository is part of the Equinor Flotilla–SARA robotics system. Sibling
+repositories that may be affected by changes here include:
+
+- **isar** — mission API and `robot_interface` definition; publishes MQTT events.
+- **isar-robot / isar-anymal / isar-taurob** — robot-specific implementations of
+  the ISAR `robot_interface`.
+- **flotilla** — operator backend (ASP.NET) + frontend (React) + Mosquitto
+  broker; consumes ISAR MQTT messages.
+- **sara** + **sara-anonymizer / sara-constant-level-oiler / sara-stid /
+  sara-thermal-reading / sara-fence-detection / sara-timeseries** — inspection
+  data platform; SARA orchestrates the analysis steps via Argo workflows and
+  ingests `IsarInspectionResultMessage` events.
+- **robotics-infrastructure / analytics-infrastructure** — Kustomize/ArgoCD
+  deployments for the above.
+- **armada** — integration-test harness that runs `flotilla`, `isar-robot` and
+  `sara` together; also the canonical source of this shared Copilot config.
+
+For the full architecture overview see the README in
+[`equinor/armada`](https://github.com/equinor/armada).
+
+## Pull request reviews
+
+When asked to review a pull request, follow the workflow in
+`.github/prompts/review-pr.prompt.md`. If that prompt file is not available in
+your Copilot surface (e.g. some IDE integrations), apply this condensed
+checklist instead:
+
+1. **Cross-repo impact.** Does the diff touch a contract used by sibling repos?
+   In particular: ISAR MQTT message models, the ISAR `robot_interface`, SARA
+   Argo workflow step inputs/outputs, shared schemas, or deployment manifests
+   under `*-infrastructure`. If so, name the sibling repo(s) that likely need a
+   coordinated PR.
+2. **Tests.** New/changed behaviour has unit or integration tests. Consider
+   whether `armada` integration tests need updating as well.
+3. **Security.** No secrets, credentials, or private endpoints committed. New
+   outbound network calls or new dependencies are justified.
+4. **Backward compatibility.** Public contracts (HTTP, MQTT topics/payloads,
+   CLI flags, config keys, database schemas) remain compatible, or a migration
+   path is documented.
+5. **Observability.** Logs and metrics are present where the change affects
+   runtime behaviour or failure modes.
+6. **Style.** Matches the repo's language conventions (C# / TypeScript /
+   Python / Kustomize) and passes the repo's existing lint/format gates.
+7. **Docs.** README or in-repo docs updated when user-visible behaviour
+   changes.
+8. **Commits & PR hygiene.** Commit messages follow the repo's convention; the
+   PR description explains the *why*, not just the *what*.
+
+Output the review as four sections — **Summary**, **Blocking**, **Suggestions**,
+**Questions** — and cite findings as `path:line`. Use `- _none_` for empty
+sections. No emojis.

--- a/scripts/sync-copilot.sh
+++ b/scripts/sync-copilot.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# sync-copilot.sh — Distribute the canonical Copilot configuration in this
+# repository (armada/.github/copilot/) into a target repository.
+#
+# Usage:
+#   ./scripts/sync-copilot.sh <path-to-target-repo>
+#
+# Behaviour:
+#   1. Writes <target>/.github/prompts/review-pr.prompt.md from
+#      armada/.github/copilot/prompts/review-pr.prompt.md, prefixed with an
+#      AUTO-GENERATED header naming the source commit SHA.
+#   2. Updates (or creates) <target>/.github/copilot-instructions.md, replacing
+#      the block between
+#          <!-- BEGIN SYNCED FROM equinor/armada@<sha> -->
+#          <!-- END SYNCED -->
+#      with the current contents of armada/.github/copilot/shared-instructions.md.
+#      Content outside the markers is preserved verbatim. If the file does not
+#      exist, it is created with a placeholder repo-specific header and the
+#      synced block appended at the bottom. If the file exists but does not
+#      yet contain the markers, the block is appended at the bottom.
+#
+# The script is idempotent: re-running it with a newer armada checkout
+# re-stamps the SHA and refreshes the synced block in place.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <path-to-target-repo>" >&2
+    exit 2
+fi
+
+target_repo="$1"
+
+if [[ ! -d "$target_repo" ]]; then
+    echo "error: target repo '$target_repo' is not a directory" >&2
+    exit 1
+fi
+
+# Resolve the armada repo root (parent of the directory containing this script).
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+armada_root="$(cd "$script_dir/.." && pwd)"
+
+src_prompt="$armada_root/.github/copilot/prompts/review-pr.prompt.md"
+src_shared="$armada_root/.github/copilot/shared-instructions.md"
+
+for f in "$src_prompt" "$src_shared"; do
+    if [[ ! -f "$f" ]]; then
+        echo "error: missing source file: $f" >&2
+        exit 1
+    fi
+done
+
+# Determine the armada commit SHA (short form). Fall back to "unknown" if the
+# tree is not a git checkout.
+if sha="$(git -C "$armada_root" rev-parse --short HEAD 2>/dev/null)"; then
+    :
+else
+    sha="unknown"
+fi
+
+begin_marker="<!-- BEGIN SYNCED FROM equinor/armada@${sha} -->"
+end_marker="<!-- END SYNCED -->"
+
+target_github_dir="$target_repo/.github"
+target_prompts_dir="$target_github_dir/prompts"
+target_prompt="$target_prompts_dir/review-pr.prompt.md"
+target_instructions="$target_github_dir/copilot-instructions.md"
+
+mkdir -p "$target_prompts_dir"
+
+# ---------------------------------------------------------------------------
+# 1. Write the prompt file (always overwrite — this is a synced artifact).
+# ---------------------------------------------------------------------------
+{
+    printf '<!-- AUTO-GENERATED from equinor/armada@%s — do not edit. Run scripts/sync-copilot.sh in armada to refresh. -->\n\n' "$sha"
+    cat "$src_prompt"
+} > "$target_prompt"
+
+echo "wrote   $target_prompt"
+
+# ---------------------------------------------------------------------------
+# 2. Build the synced block to inject into copilot-instructions.md.
+# ---------------------------------------------------------------------------
+synced_block="$(
+    printf '%s\n' "$begin_marker"
+    printf '<!-- AUTO-GENERATED — do not edit between these markers. Run scripts/sync-copilot.sh in armada to refresh. -->\n\n'
+    cat "$src_shared"
+    printf '\n%s\n' "$end_marker"
+)"
+
+if [[ ! -f "$target_instructions" ]]; then
+    # Create a fresh file with a placeholder repo-specific section followed by
+    # the synced block.
+    {
+        cat <<'EOF'
+# Copilot instructions
+
+<!-- Repo-specific guidance goes here. Hand-edit freely above the synced
+     block. The synced block at the bottom is overwritten by
+     equinor/armada/scripts/sync-copilot.sh. -->
+
+EOF
+        printf '%s\n' "$synced_block"
+    } > "$target_instructions"
+    echo "created $target_instructions"
+else
+    # Existing file: replace the marker block, or append it if no markers yet.
+    python3 - "$target_instructions" "$synced_block" <<'PYEOF'
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+synced_block = sys.argv[2]
+
+text = path.read_text()
+
+pattern = re.compile(
+    r"<!-- BEGIN SYNCED FROM equinor/armada@[^\s>]+ -->.*?<!-- END SYNCED -->",
+    re.DOTALL,
+)
+
+if pattern.search(text):
+    new_text = pattern.sub(lambda _: synced_block.rstrip("\n"), text)
+    action = "updated"
+else:
+    sep = "" if text.endswith("\n\n") else ("\n" if text.endswith("\n") else "\n\n")
+    new_text = text + sep + synced_block
+    action = "appended"
+
+path.write_text(new_text)
+print(f"{action} synced block in {path}")
+PYEOF
+fi
+
+echo
+echo "Done. Source: equinor/armada@${sha}"


### PR DESCRIPTION
## Summary
- Introduces a canonical Copilot configuration under `.github/copilot/` that can be distributed to sibling Flotilla-SARA repositories (`flotilla`, `isar`, `sara`, ...).
- Adds `scripts/sync-copilot.sh` which writes a SHA-stamped copy of `prompts/review-pr.prompt.md` and injects `shared-instructions.md` into a target repo's `.github/copilot-instructions.md` between `<!-- BEGIN SYNCED FROM equinor/armada@<sha> -->` / `<!-- END SYNCED -->` markers.
- The first shared artifact is a PR-review prompt with explicit cross-repo impact checks (ISAR MQTT messages, `robot_interface`, SARA Argo step contracts, `*-infrastructure` manifests) and a structured **Summary / Blocking / Suggestions / Questions** output.

## Why armada
`armada` already orchestrates the whole Flotilla-SARA system in integration tests, so it is a natural single source of truth for cross-system review heuristics.

## How to consume in another repo
```bash
./scripts/sync-copilot.sh <path-to-target-repo>
```
The script is idempotent: hand-edited content outside the markers is preserved; the synced block and prompt are refreshed in place on every run.

## Pilot
A companion PR pulls these files into `equinor/flotilla` as the first consumer.