### PR TITLE
Update SARA readiness probe to use analysis-group endpoint

### DIFF
--- a/robotics_integration_tests/utilities/sara_backend_api.py
+++ b/robotics_integration_tests/utilities/sara_backend_api.py
@@ -41,8 +41,8 @@ def wait_for_sara_to_be_responsive(sara_url: str, timeout: int = 60) -> None:
             )
 
         try:
-            analysis_mapping: List[Dict] = _list_database_entries(
-                backend_url=sara_url, request_path="api/AnalysisMapping"
+            analysis_groups: List[Dict] = _list_database_entries(
+                backend_url=sara_url, request_path="api/analysis-group"
             )
         except Exception as e:
             logger.warning(
@@ -51,7 +51,7 @@ def wait_for_sara_to_be_responsive(sara_url: str, timeout: int = 60) -> None:
             time.sleep(1)
             continue
 
-        if len(analysis_mapping) >= 0:
+        if len(analysis_groups) >= 0:
             logger.info("Sara is responsive")
             return
 


### PR DESCRIPTION
## Summary
- `wait_for_sara_to_be_responsive` probed `GET api/AnalysisMapping`, but that controller was removed from SARA in equinor/sara@1e8a8b0 ("Rebuild SARA around generic Analysis pipeline"). The probe now always 404s, causing the integration-test pipeline to fail on main after the 60s timeout.
- Switched the probe to `GET api/analysis-group` (`AnalysisGroupController.GetAll`, `[Authorize(Roles = Role.Any)]`), which is the closest equivalent in the new generic Analysis pipeline and exercises the same auth + DB round-trip.

## Notes
- SARA logs around the failure (e.g. the `libgssapi_krb5.so.2` warning from Npgsql) are unrelated; SARA binds to `0.0.0.0:8100` successfully and is just returning 404 for the stale probe URL.