### PR TITLE
Migrate run_dotnet_migrations to OIDC federated credentials

### DIFF
--- a/.github/workflows/run_dotnet_migrations.yml
+++ b/.github/workflows/run_dotnet_migrations.yml
@@ -31,15 +31,19 @@ on:
         required: false
         type: string
         default: "10.0.*"
-    secrets:
-      client_id:
+      azure_client_id:
+        description: "Azure AD application (client) ID used for OIDC federated login"
         required: true
-      client_secret:
+        type: string
+      azure_subscription_id:
+        description: "Azure subscription ID used for OIDC federated login"
         required: true
+        type: string
 
 permissions:
   contents: read
   pull-requests: read
+  id-token: write
 
 jobs:
   run_migrations:
@@ -53,6 +57,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
         with:
           ref: ${{ inputs.pr_head_sha || inputs.checkout_ref }}
+
+      - name: Azure login (OIDC / federated credential)
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 #v2.3.0
+        with:
+          client-id: ${{ inputs.azure_client_id }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ inputs.azure_subscription_id }}
 
       - name: Set up .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5
@@ -68,9 +79,8 @@ jobs:
       - name: Update database
         run: dotnet ef database update --no-build --verbose
         env:
-          AZURE_CLIENT_ID: ${{ secrets.client_id }}
-          AZURE_CLIENT_SECRET: ${{ secrets.client_secret }}
+          # azure/login above has injected AZURE_FEDERATED_TOKEN_FILE so that
+          # WorkloadIdentityCredential can acquire tokens without a client secret.
+          AZURE_CLIENT_ID: ${{ inputs.azure_client_id }}
           AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
           ASPNETCORE_ENVIRONMENT: ${{ vars.AspNetEnvironment }}
-          AzureAd__ClientSecret: ${{ secrets.client_secret }}
-          AzureAd__ClientId: ${{ secrets.client_id }}


### PR DESCRIPTION
## Summary
- Replace ClientSecret-based authentication in the reusable `run_dotnet_migrations.yml` workflow with GitHub Actions OIDC federated credentials via `azure/login`.
- Add required inputs `azure_client_id` and `azure_subscription_id`; remove the `client_id`/`client_secret` secret inputs.
- Grant `id-token: write` and run `azure/login@v2.3.0` (SHA-pinned) so that `AZURE_FEDERATED_TOKEN_FILE` is injected and `WorkloadIdentityCredential` succeeds on the runner.
- Slim the `dotnet ef` env block to `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `ASPNETCORE_ENVIRONMENT` (no client secret, no `AzureAd__*` overrides).

## Breaking change
Callers must:
1. Pass `azure_client_id` and `azure_subscription_id` inputs.
2. Drop the `secrets:` block (`client_id`/`client_secret`).
3. Grant `id-token: write` on the calling job.
4. Have a GitHub Actions federated credential on the relevant app registration with subject `repo:<org>/<repo>:environment:<Environment>` and audience `api://AzureADTokenExchange`.

## Affected callers
- `equinor/sara` — migration PR ready: equinor/sara#386
- `equinor/flotilla` — migration PR ready: equinor/flotilla#2764

Both downstream PRs should be merged immediately after this one to minimize the breakage window.

## Why
Closes the loop on equinor/sara#347 (federated credentials migration). Pods already run on workload identity in cloud; the migration runner was the last consumer of the long-lived ClientSecret.