### PR TITLE
Read CLIENTID from environment-scoped GitHub variable

### DIFF
--- a/.github/workflows/run_dotnet_migrations.yml
+++ b/.github/workflows/run_dotnet_migrations.yml
@@ -31,10 +31,6 @@ on:
         required: false
         type: string
         default: "10.0.*"
-      azure_client_id:
-        description: "Azure AD application (client) ID used for OIDC federated login"
-        required: true
-        type: string
       azure_subscription_id:
         description: "Azure subscription ID used for OIDC federated login"
         required: true
@@ -61,7 +57,10 @@ jobs:
       - name: Azure login (OIDC / federated credential)
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 #v2.3.0
         with:
-          client-id: ${{ inputs.azure_client_id }}
+          # vars.CLIENTID is an environment-scoped variable resolved via the
+          # job's environment: ${{ inputs.environment }} above. It must be
+          # defined on the calling repo's GitHub Environment.
+          client-id: ${{ vars.CLIENTID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ inputs.azure_subscription_id }}
 
@@ -81,6 +80,6 @@ jobs:
         env:
           # azure/login above has injected AZURE_FEDERATED_TOKEN_FILE so that
           # WorkloadIdentityCredential can acquire tokens without a client secret.
-          AZURE_CLIENT_ID: ${{ inputs.azure_client_id }}
+          AZURE_CLIENT_ID: ${{ vars.CLIENTID }}
           AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
           ASPNETCORE_ENVIRONMENT: ${{ vars.AspNetEnvironment }}


### PR DESCRIPTION
## Summary
Resolve the workflow validation failure caused by referencing \`secrets.CLIENTID\` in caller \`with:\` blocks, while moving CLIENTID off of secrets entirely (it is a public Azure AD application ID, not sensitive).

## Approach
Read \`vars.CLIENTID\` directly inside the reusable workflow's env-scoped job. This avoids passing the value through the caller at all.

- Drop the \`azure_client_id\` parameter from the reusable workflow (was previously declared as either an input or a secret in the prior PR iterations).
- In the \`azure/login\` step and the \`dotnet ef\` env block, reference \`\${{ vars.CLIENTID }}\` directly. The job already declares \`environment: \${{ inputs.environment }}\`, so env-scoped vars resolve correctly here.

## Why this pattern is necessary
Per the GitHub Actions [Context availability table](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability):
- \`secrets\` is not available in \`jobs.<job_id>.with.<with_id>\` of a reusable-workflow caller.
- \`vars\` is allowed in \`with:\`, but **environment-scoped** vars only resolve in jobs that have \`environment:\` set on them, which a caller \`uses:\` job does not.

Reading \`vars.CLIENTID\` from inside the env-scoped reusable job is the reliable way to access env-scoped values.

## Caller requirements
Each calling repo must define \`CLIENTID\` as an **environment variable** on each GitHub Environment (Development/Staging/Production) it uses with this reusable workflow.

## Caller updates
- equinor/sara — companion PR drops \`azure_client_id\` from the 3 migration workflows.
- equinor/flotilla — companion PR drops \`azure_client_id\` from the 3 migration workflows.