### PR TITLE
Provision federated token file for WorkloadIdentityCredential

### DIFF
--- a/.github/actions/azure-federated-token/action.yml
+++ b/.github/actions/azure-federated-token/action.yml
@@ -1,0 +1,82 @@
+name: "Provision Azure federated token file"
+description: >-
+  Fetch a GitHub Actions OIDC JWT and write it to a file so that the
+  azure-identity SDK's WorkloadIdentityCredential can authenticate to Entra ID
+  without a client secret. Sets AZURE_FEDERATED_TOKEN_FILE on the job
+  environment.
+
+  Why a composite action and not azure/login?
+  azure/login authenticates the Azure CLI: it consumes the GitHub OIDC JWT,
+  exchanges it for an Azure access token, and stashes that access token in
+  ~/.azure/. It does NOT persist the GitHub JWT to disk, and the
+  azure-identity SDK's WorkloadIdentityCredential reads the JWT from a file
+  on disk (the same contract used by AKS workload identity). Until
+  Azure/login ships an option to write the federated token file, we provision
+  it ourselves with the same one-line OIDC token request that azure/login
+  performs internally.
+
+  Requirements:
+    * The calling job (or workflow) must grant `permissions: id-token: write`
+      so that ACTIONS_ID_TOKEN_REQUEST_URL and ACTIONS_ID_TOKEN_REQUEST_TOKEN
+      are injected by the runner.
+    * The target Entra app registration must have a federated credential that
+      trusts the GitHub OIDC issuer for this repo/environment/branch and the
+      audience supplied via `audience` (default api://AzureADTokenExchange).
+
+inputs:
+  audience:
+    description: >-
+      OIDC audience that the app registration's federated credential trusts.
+      Defaults to api://AzureADTokenExchange, which matches the default used
+      by Entra ID federated credentials of type "GitHub Actions".
+    required: false
+    default: "api://AzureADTokenExchange"
+  token-file:
+    description: >-
+      Absolute path where the federated token JWT will be written. Defaults
+      to $RUNNER_TEMP/azure-federated-token. Override only if you need a
+      specific path (e.g. for a sidecar/container that mounts a fixed path).
+    required: false
+    default: ""
+
+outputs:
+  token-file:
+    description: "Absolute path to the file containing the federated token JWT."
+    value: ${{ steps.write.outputs.token-file }}
+
+runs:
+  using: composite
+  steps:
+    - name: Write federated token file
+      id: write
+      shell: bash
+      env:
+        AZURE_AD_AUDIENCE: ${{ inputs.audience }}
+        TOKEN_FILE_OVERRIDE: ${{ inputs.token-file }}
+      run: |
+        set -euo pipefail
+
+        if [[ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" || -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]]; then
+          echo "::error::ACTIONS_ID_TOKEN_REQUEST_URL/TOKEN are not set. Did you grant 'permissions: id-token: write' on the calling job or workflow?" >&2
+          exit 1
+        fi
+
+        TOKEN_FILE="${TOKEN_FILE_OVERRIDE:-$RUNNER_TEMP/azure-federated-token}"
+        AUDIENCE_URLENC=$(jq -nr --arg a "$AZURE_AD_AUDIENCE" '$a|@uri')
+
+        # Request the GitHub Actions OIDC JWT for the requested audience and
+        # write the raw JWT (not an Azure access token) to disk so that
+        # WorkloadIdentityCredential can read it.
+        curl -sSL --fail \
+          -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+          "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=$AUDIENCE_URLENC" \
+          | jq -r .value > "$TOKEN_FILE"
+
+        if [[ ! -s "$TOKEN_FILE" ]]; then
+          echo "::error::Federated token file is empty: $TOKEN_FILE" >&2
+          exit 1
+        fi
+        chmod 600 "$TOKEN_FILE"
+
+        echo "AZURE_FEDERATED_TOKEN_FILE=$TOKEN_FILE" >> "$GITHUB_ENV"
+        echo "token-file=$TOKEN_FILE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/run_dotnet_migrations.yml
+++ b/.github/workflows/run_dotnet_migrations.yml
@@ -32,9 +32,10 @@ on:
         type: string
         default: "10.0.*"
       azure_subscription_id:
-        description: "Azure subscription ID used for OIDC federated login"
-        required: true
+        description: "Azure subscription ID. Currently unused; kept for backward compatibility with existing callers."
+        required: false
         type: string
+        default: ""
 
 permissions:
   contents: read
@@ -54,15 +55,28 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.checkout_ref }}
 
-      - name: Azure login (OIDC / federated credential)
-        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 #v2.3.0
-        with:
-          # vars.CLIENTID is an environment-scoped variable resolved via the
-          # job's environment: ${{ inputs.environment }} above. It must be
-          # defined on the calling repo's GitHub Environment.
-          client-id: ${{ vars.CLIENTID }}
-          tenant-id: ${{ vars.AZURE_TENANT_ID }}
-          subscription-id: ${{ inputs.azure_subscription_id }}
+      - name: Provision GitHub OIDC token for WorkloadIdentityCredential
+        # azure/login is intentionally not used here: it only authenticates the
+        # az CLI and does not write the federated token to a file, which is
+        # what the azure-identity SDK's WorkloadIdentityCredential requires.
+        # We fetch the GitHub Actions OIDC JWT for the audience that the app
+        # registration's federated credential trusts, write it to a file under
+        # RUNNER_TEMP, and export AZURE_FEDERATED_TOKEN_FILE so that the SDK
+        # picks it up. AZURE_CLIENT_ID and AZURE_TENANT_ID are set on the
+        # dotnet ef step below.
+        shell: bash
+        env:
+          AZURE_AD_AUDIENCE: api://AzureADTokenExchange
+        run: |
+          set -euo pipefail
+          TOKEN_FILE="$RUNNER_TEMP/azure-federated-token"
+          AUDIENCE_URLENC=$(jq -nr --arg a "$AZURE_AD_AUDIENCE" '$a|@uri')
+          curl -sSL \
+            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=$AUDIENCE_URLENC" \
+            | jq -r .value > "$TOKEN_FILE"
+          test -s "$TOKEN_FILE"
+          echo "AZURE_FEDERATED_TOKEN_FILE=$TOKEN_FILE" >> "$GITHUB_ENV"
 
       - name: Set up .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5
@@ -78,8 +92,9 @@ jobs:
       - name: Update database
         run: dotnet ef database update --no-build --verbose
         env:
-          # azure/login above has injected AZURE_FEDERATED_TOKEN_FILE so that
-          # WorkloadIdentityCredential can acquire tokens without a client secret.
+          # AZURE_FEDERATED_TOKEN_FILE is exported above. Together with these
+          # two values, azure-identity's WorkloadIdentityCredential can acquire
+          # tokens without a client secret.
           AZURE_CLIENT_ID: ${{ vars.CLIENTID }}
           AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
           ASPNETCORE_ENVIRONMENT: ${{ vars.AspNetEnvironment }}

--- a/.github/workflows/run_dotnet_migrations.yml
+++ b/.github/workflows/run_dotnet_migrations.yml
@@ -55,28 +55,14 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.checkout_ref }}
 
-      - name: Provision GitHub OIDC token for WorkloadIdentityCredential
-        # azure/login is intentionally not used here: it only authenticates the
-        # az CLI and does not write the federated token to a file, which is
-        # what the azure-identity SDK's WorkloadIdentityCredential requires.
-        # We fetch the GitHub Actions OIDC JWT for the audience that the app
-        # registration's federated credential trusts, write it to a file under
-        # RUNNER_TEMP, and export AZURE_FEDERATED_TOKEN_FILE so that the SDK
-        # picks it up. AZURE_CLIENT_ID and AZURE_TENANT_ID are set on the
-        # dotnet ef step below.
-        shell: bash
-        env:
-          AZURE_AD_AUDIENCE: api://AzureADTokenExchange
-        run: |
-          set -euo pipefail
-          TOKEN_FILE="$RUNNER_TEMP/azure-federated-token"
-          AUDIENCE_URLENC=$(jq -nr --arg a "$AZURE_AD_AUDIENCE" '$a|@uri')
-          curl -sSL \
-            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=$AUDIENCE_URLENC" \
-            | jq -r .value > "$TOKEN_FILE"
-          test -s "$TOKEN_FILE"
-          echo "AZURE_FEDERATED_TOKEN_FILE=$TOKEN_FILE" >> "$GITHUB_ENV"
+      - name: Provision Azure federated token file
+        # See equinor/armada/.github/actions/azure-federated-token for the
+        # rationale on why azure/login is not used here. In short: azure/login
+        # authenticates the az CLI but does not write a federated token file,
+        # which is what the azure-identity SDK's WorkloadIdentityCredential
+        # reads to acquire tokens without a client secret. AZURE_CLIENT_ID and
+        # AZURE_TENANT_ID are set on the dotnet ef step below.
+        uses: equinor/armada/.github/actions/azure-federated-token@main
 
       - name: Set up .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5


### PR DESCRIPTION
## Summary
- Add a composite action `equinor/armada/.github/actions/azure-federated-token` that fetches the GitHub Actions OIDC JWT and writes it to a file, exporting `AZURE_FEDERATED_TOKEN_FILE`.
- Replace `azure/login` in `run_dotnet_migrations.yml` with a single `uses:` step pointing at the new composite action.
- Mark `azure_subscription_id` as optional (default `""`) and document it as unused, preserving backward compatibility with existing sara/flotilla callers in a single PR.

## Why not `azure/login`?
`azure/login` (latest v3.0.0) authenticates the **Azure CLI**: it consumes the GitHub OIDC JWT, exchanges it for an Azure access token, and stashes that access token in `~/.azure/`. It does **not** persist the GitHub JWT to disk.

The .NET `azure-identity` SDK's `WorkloadIdentityCredential` reads the JWT from a file on disk (the same contract used by AKS workload identity via `AZURE_FEDERATED_TOKEN_FILE`). Without that file, `dotnet ef database update` fails with `CredentialUnavailableException: workload options are not fully configured`.

There is no input on any released `azure/login` version (v1.x → v3.0.0) that writes the federated token file. Until upstream adds that, we provision it ourselves with the same one-line OIDC token request that `azure/login` performs internally — wrapped in a named, reusable composite action.

## Sara failure trace addressed
- `AppRegIdentity` skipped (Phase 5 PG Entra-ID activation pending).
- `ConnectionString` path → `ClientSecretCredential` skipped (no secret) → `WorkloadIdentityCredential` selected → fails because `AZURE_FEDERATED_TOKEN_FILE` is unset.

The SDK requires all three of `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_FEDERATED_TOKEN_FILE`. The first two were exported on the `dotnet ef` step; this PR provides the third.

## Composite action notes
- Audience is URL-encoded via `jq -nr --arg a … '$a|@uri'` (default `api://AzureADTokenExchange`, overridable via `audience` input).
- Token file path defaults to `$RUNNER_TEMP/azure-federated-token`, overridable via `token-file` input.
- `chmod 600` on the token file.
- Fails loudly if `ACTIONS_ID_TOKEN_REQUEST_URL`/`_TOKEN` are unset (most commonly: missing `permissions: id-token: write`).
- A single token write is sufficient for the run; the GH OIDC JWT (5–10 min lifetime) is exchanged once by the SDK for a 1h Azure access token.
- No caller changes needed (sara #387, flotilla #2765 unaffected).