### PR TITLE
Document Azure CLI credential requirement in migration workflow comment

### DIFF
--- a/.github/workflows/run_dotnet_migrations.yml
+++ b/.github/workflows/run_dotnet_migrations.yml
@@ -78,8 +78,11 @@ jobs:
       - name: Update database
         run: dotnet ef database update --no-build --verbose
         env:
-          # azure/login above has injected AZURE_FEDERATED_TOKEN_FILE so that
-          # WorkloadIdentityCredential can acquire tokens without a client secret.
+          # azure/login above has populated ~/.azure/ on the runner. Callers
+          # must include "AzureCliBootstrap" (or another credential type that
+          # consults the Azure CLI cache) in their AzureAd:AllowedAuthMethods
+          # so that the application's credential chain can authenticate to
+          # Azure without a client secret and without a federated token file.
           AZURE_CLIENT_ID: ${{ vars.CLIENTID }}
           AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
           ASPNETCORE_ENVIRONMENT: ${{ vars.AspNetEnvironment }}


### PR DESCRIPTION
## Summary
Update the comment above the `Update database` step in `run_dotnet_migrations.yml`. The previous comment incorrectly claimed that `azure/login` injects `AZURE_FEDERATED_TOKEN_FILE`; it does not. `azure/login` populates `~/.azure/`, which is consumed by `AzureCliCredential` in callers' credential chains.

## Why
Sara's CI migration job failed because `WorkloadIdentityCredential` requires a federated token file on disk (the AKS workload-identity contract), and `azure/login` does not provide one. The fix is on the caller side: include a CLI-aware credential in the chain. See:

- equinor/sara#388 — adds `"AzureCliBootstrap"` to `AzureAd:AllowedAuthMethods`.
- Flotilla — no change needed; its design-time factory already uses `DefaultAzureCredential`, which includes `AzureCliCredential` in its chain.

## Behavior change
None. Comment-only update.