### PR TITLE
Force migrations onto Key Vault connection string

### DIFF
--- a/.github/workflows/run_dotnet_migrations.yml
+++ b/.github/workflows/run_dotnet_migrations.yml
@@ -86,3 +86,14 @@ jobs:
           AZURE_CLIENT_ID: ${{ vars.CLIENTID }}
           AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
           ASPNETCORE_ENVIRONMENT: ${{ vars.AspNetEnvironment }}
+          # Force the design-time DbContext factory onto the Key Vault
+          # connection string. Schema migrations require DDL privileges; the
+          # runtime app-registration role typically only has CRUD grants and
+          # cannot run ALTER TABLE / CREATE TABLE on tables it does not own.
+          # The Key Vault connection string authenticates as the PostgreSQL
+          # admin (postgresuser), which retains ownership of the schema and
+          # can perform DDL safely.
+          # Apps whose Database:AllowedAuthMethods config key isn't honored
+          # (e.g. those that hard-code the design-time auth method) ignore
+          # this variable harmlessly.
+          Database__AllowedAuthMethods__0: ConnectionString


### PR DESCRIPTION
## Summary

Migration jobs need DDL privileges that the runtime app-registration role doesn't have. This sets `Database__AllowedAuthMethods__0=ConnectionString` on the migration step so design-time DbContext factories pick up the Key Vault connection string (authenticating as the PostgreSQL admin) instead of falling back to the runtime managed identity.

Apps whose design-time factory ignores `Database:AllowedAuthMethods` (e.g. flotilla, which hard-codes the connection-string path) are unaffected.