### PR TITLE
Pin sara integration-test container to ConnectionString auth

### DIFF
--- a/robotics_integration_tests/custom_containers/sara.py
+++ b/robotics_integration_tests/custom_containers/sara.py
@@ -43,6 +43,13 @@ def create_sara_container(
         .with_env("Mqtt__Password", settings.SARA_MQTT_PASSWORD)
         .with_env("Mqtt__Username", "sara")
         .with_env("ASPNETCORE_ENVIRONMENT", settings.ASPNETCORE_ENVIRONMENT)
+        # Pin the integration-test container to the ConnectionString auth path.
+        # sara's appsettings.Development.json now lists AppRegIdentity first
+        # (equinor/sara#396), which would otherwise wire EF Core against the
+        # dev Azure PostgreSQL server (unreachable from the test docker
+        # network). Mirrors the migration-workflow override in
+        # .github/workflows/run_dotnet_migrations.yml (PR #73).
+        .with_env("Database__AllowedAuthMethods__0", "ConnectionString")
         .with_env("AZURE_CLIENT_SECRET", settings.SARA_AZURE_CLIENT_SECRET)
         .with_env("AZURE_CLIENT_ID", settings.SARA_AZURE_CLIENT_ID)
         .with_env("AZURE_TENANT_ID", settings.SARA_AZURE_TENANT_ID)


### PR DESCRIPTION
## Summary

`equinor/sara#396` populated `Database:Server` / `User` / `PostgresDatabase` in `appsettings.Development.json` so dev pods can authenticate against Azure PostgreSQL via Entra ID (`AppRegIdentity`). Side-effect: the integration-test container, which also runs with `ASPNETCORE_ENVIRONMENT=Development`, now succeeds at `AppRegIdentity` registration and wires EF Core against `robotics-dev-psql-server.postgres.database.azure.com` — unreachable from the test docker network. Symptom: `RuntimeError: sara was not responsive` during integration runs.

This PR sets `Database__AllowedAuthMethods__0=ConnectionString` on `create_sara_container`, forcing the container to use the existing `Database__postgresConnectionString` env var that points at the in-network test Postgres. Mirrors the migration-workflow override added in #73.