### PR TITLE
Fix pnpm dependency workflow cache and lockfile updates

### DIFF
--- a/.github/workflows/pnpm_dependency_update_and_create_pr.yml
+++ b/.github/workflows/pnpm_dependency_update_and_create_pr.yml
@@ -64,6 +64,16 @@ jobs:
         if: ${{ inputs.operation == 'audit-fix' }}
         run: pnpm audit --fix
 
+      # `pnpm audit --fix` only writes overrides to package.json /
+      # pnpm-workspace.yaml; it does not refresh pnpm-lock.yaml. Running
+      # `pnpm install` here both applies the overrides to the lockfile and
+      # populates the pnpm store so the `cache: pnpm` post-step in
+      # actions/setup-node has a path to cache (otherwise it fails with
+      # "Path Validation Error: Path(s) specified in the action for caching
+      # do(es) not exist").
+      - name: Install dependencies to update lockfile and populate cache
+        run: pnpm install --no-frozen-lockfile
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 #v8
         with:


### PR DESCRIPTION
## Summary
- Add a `pnpm install --no-frozen-lockfile` step after `pnpm audit --fix` / `pnpm update` in the reusable `pnpm_dependency_update_and_create_pr.yml` workflow.

## Why
The current workflow has two issues when `operation: audit-fix` is used (e.g. the `Frontend dependency security fix` workflow in `equinor/sara`):

1. **Stale lockfile in the generated PR.** `pnpm audit --fix` only writes overrides to `package.json` / `pnpm-workspace.yaml`; it does not refresh `pnpm-lock.yaml`. The resulting PR therefore contains overrides that aren't reflected in the lockfile, so CI builds using `--frozen-lockfile` won't actually pick up the security fix.
2. **Job failure on the post-step.** `actions/setup-node` is configured with `cache: pnpm`, which queries `pnpm store path` and tries to cache it on cleanup. Because no install ever ran, the store directory doesn't exist and the post step fails with:
   > `Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.`

   Example failed run in sara: https://github.com/equinor/sara/actions/runs/28373777477/job/84058020844

Running `pnpm install --no-frozen-lockfile` after the audit/update step fixes both: it applies overrides to the lockfile and populates the pnpm store so caching succeeds.