### PR TITLE
Retry update_kubernetes_deployment push on concurrent-push race

### DIFF
--- a/.github/workflows/update_kubernetes_deployment.yml
+++ b/.github/workflows/update_kubernetes_deployment.yml
@@ -68,31 +68,50 @@ jobs:
           repository: ${{ inputs.infrastructure_repository }}
           ssh-key: ${{ secrets.deploy_key }}
 
-      - name: Update image tag in kustomization
+      - name: Update tag, commit, push (retry on concurrent push)
         run: |
-          KUSTOMIZATION_FILE="k8s_kustomize/overlays/${{ inputs.environment }}/kustomization.yaml"
+          set -euo pipefail
 
-          GREP_RESULT=$(grep -n "newName: ${{ inputs.registry }}/${{ inputs.image_name }}$" "$KUSTOMIZATION_FILE" | cut -d ':' -f 1)
-          if [ -z "$GREP_RESULT" ]; then
-            echo "Error: Image ${{ inputs.registry }}/${{ inputs.image_name }} not found in $KUSTOMIZATION_FILE"
-            exit 1
-          fi
-
-          LINE_NUMBERS=($GREP_RESULT)
-          for line_number in "${LINE_NUMBERS[@]}"
-          do
-              TAG_LINE_NUMBER=$((line_number + 1))
-              sed -i "${TAG_LINE_NUMBER} s/newTag:.*/newTag: ${{ inputs.tag }}/" "$KUSTOMIZATION_FILE"
-          done
-
-      - name: Commit and push changes
-        run: |
           git config --global user.email "${EMAIL}"
           git config --global user.name  "GitHub Actions (${NAME})"
-          git add k8s_kustomize/overlays/${{ inputs.environment }}/kustomization.yaml
-          if ! git diff-index --quiet HEAD; then
+
+          KUSTOMIZATION_FILE="k8s_kustomize/overlays/${{ inputs.environment }}/kustomization.yaml"
+          MAX_ATTEMPTS=5
+
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            # Resync to remote main before each attempt so we always commit
+            # against its current tip. Prevents non-fast-forward rejects when
+            # multiple deploys race (e.g. SARA promote fanning out).
+            git fetch origin main
+            git reset --hard origin/main
+
+            GREP_RESULT=$(grep -n "newName: ${{ inputs.registry }}/${{ inputs.image_name }}$" "$KUSTOMIZATION_FILE" | cut -d ':' -f 1 || true)
+            if [ -z "$GREP_RESULT" ]; then
+              echo "Error: Image ${{ inputs.registry }}/${{ inputs.image_name }} not found in $KUSTOMIZATION_FILE"
+              exit 1
+            fi
+
+            for line_number in $GREP_RESULT; do
+              TAG_LINE_NUMBER=$((line_number + 1))
+              sed -i "${TAG_LINE_NUMBER} s/newTag:.*/newTag: ${{ inputs.tag }}/" "$KUSTOMIZATION_FILE"
+            done
+
+            git add "$KUSTOMIZATION_FILE"
+            if git diff-index --quiet HEAD; then
+              echo "No changes to commit or push (tag already up to date on origin/main)."
+              exit 0
+            fi
+
             git commit --message "GHA: Update ${SERVICE_NAME} in ${{ inputs.environment }} (${{ inputs.tag }})"
-            git push
-          else
-            echo "No changes to commit or push."
-          fi
+
+            if git push origin HEAD:main; then
+              echo "Push succeeded on attempt ${attempt}."
+              exit 0
+            fi
+
+            echo "Push rejected on attempt ${attempt}; another job likely raced. Backing off and retrying."
+            sleep $(( attempt * 5 ))
+          done
+
+          echo "Error: failed to push after ${MAX_ATTEMPTS} attempts."
+          exit 1


### PR DESCRIPTION
## Summary
- Two or more callers of `update_kubernetes_deployment.yml` hitting the same infrastructure repo `main` at once race on `git push` — one wins, the rest fail with a non-fast-forward reject and require a manual rerun. Observed as a flake on `sara-timeseries` `deploy_to_development` after the SARA promote fanned out multiple tag bumps against `analytics-infrastructure` `main`.
- Wraps the tag-edit + commit + push sequence in a retry loop (up to 5 attempts, linear back-off). Each attempt starts with `git fetch origin main && git reset --hard origin/main`, re-applies the `sed`, commits, and pushes. If another job's commit landed in between, the reset picks it up and we replay on top; the `sed` is idempotent so no data is lost.
- Merges the previous two-step (`Update image tag in kustomization` + `Commit and push changes`) into a single step so the retry envelops both. Explicit `git push origin HEAD:main` to keep the refspec unambiguous.
- Preserves the existing early-exit when the tag is already up to date (avoids empty commits when a peer job pushed the same tag first).

## Behaviour
- Happy path: identical — one fetch, one commit, one push.
- Race path: previously would fail the job; now transparently re-syncs, replays the edit, and pushes on the next attempt.
- Hard failure (5 consecutive rejections): fails the job with a clear message rather than silently masking a real conflict.

## Test plan
- Static: `sed`/`grep` logic unchanged; only the surrounding control flow moved.
- Runtime: next SARA promote or any parallel `deploy_to_development` fan-out will exercise it. Since this workflow is `workflow_call`-only, no additional trigger wiring needed.